### PR TITLE
Fix for when a shard has a comma on the name

### DIFF
--- a/src/main/java/com/appdynamics/extensions/elasticsearch/ElasticSearchMonitorTask.java
+++ b/src/main/java/com/appdynamics/extensions/elasticsearch/ElasticSearchMonitorTask.java
@@ -88,7 +88,8 @@ public class ElasticSearchMonitorTask implements Runnable{
 
     public void printMetric(String metricName, String metricValue) {
         if (metricValue != null) {
-            //logger.debug(metricName + " : " + metricValue);
+            // logger.debug(metricName + " : " + metricValue);
+            metricName = metricName.replace(",", "_"); // There can be commas on the shards names that break the extension
             configuration.getMetricWriter().printMetric(metricName, metricValue, MetricWriter.METRIC_AGGREGATION_TYPE_AVERAGE,MetricWriter.METRIC_TIME_ROLLUP_TYPE_AVERAGE, MetricWriter.METRIC_CLUSTER_ROLLUP_TYPE_COLLECTIVE);
         } else {
             logger.warn("The metric at " + metricName + " is null");


### PR DESCRIPTION
If there is a comma "," on a metric name the extension fails. This happens when I tried monitoring the Elastic Search that comes installed with the AppDynamics Events Service

```
[Monitor-Task-Thread4] 10 May 2018 16:47:20,486  WARN ElasticSearchMonitorTask - Server|Component:14|Custom Metrics|Elastic Search|Server1|Shards|events-service-api-store-es3.localdomain-25123,events-service-api-store-es3.localdomain-25123|Shards|event_type_extracted_fields|shard : 0
[Monitor-Task-Thread4] 10 May 2018 16:47:20,486 ERROR ElasticSearchMonitorTask - Exception while running the Elastic Search task in the server Server1
java.lang.IllegalArgumentException: Invalid data line format
        at com.singularity.ee.agent.systemagent.components.monitormanager.managed.MonitorOutputHandler.createTokenMap(MonitorOutputHandler.java:26)
        at com.singularity.ee.agent.systemagent.components.monitormanager.managed.MonitorOutputHandler.createTokenMap(MonitorOutputHandler.java:37)
        at com.singularity.ee.agent.systemagent.components.monitormanager.managed.MetricOutputHandler.parseAndReportLine(MetricOutputHandler.java:59)
        at com.singularity.ee.agent.systemagent.components.monitormanager.managed.MonitorStreamConsumer.parseAndReportLineForMonitor(MonitorStreamConsumer.java:79)
        at com.singularity.ee.agent.systemagent.components.monitormanager.managed.MonitorStreamConsumer.consumeLine(MonitorStreamConsumer.java:38)
        at com.singularity.ee.agent.systemagent.api.AJavaTask.println(AJavaTask.java:50)
        at com.singularity.ee.agent.systemagent.api.AManagedMonitor.println(AManagedMonitor.java:10)
        at com.singularity.ee.agent.systemagent.api.MetricWriter.printMetric(MetricWriter.java:79)
        at com.appdynamics.extensions.util.MetricWriteHelper.printMetric(MetricWriteHelper.java:49)
        at com.appdynamics.extensions.elasticsearch.ElasticSearchMonitorTask.printMetric(ElasticSearchMonitorTask.java:92)
        at com.appdynamics.extensions.elasticsearch.ElasticSearchMonitorTask.printMetrics(ElasticSearchMonitorTask.java:84)
        at com.appdynamics.extensions.elasticsearch.ElasticSearchMonitorTask.fetchMetrics(ElasticSearchMonitorTask.java:74)
        at com.appdynamics.extensions.elasticsearch.ElasticSearchMonitorTask.run(ElasticSearchMonitorTask.java:42)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)

```